### PR TITLE
Support custom routes

### DIFF
--- a/src/FileRouter.php
+++ b/src/FileRouter.php
@@ -50,10 +50,6 @@ final class FileRouter implements MiddlewareInterface
         $possibleEntrypoints = $this->parseRequestPath($request);
 
         foreach ($possibleEntrypoints as $possibleEntrypoint) {
-            if (empty($possibleEntrypoint)) {
-                continue;
-            }
-
             /**
              * @psalm-var class-string $controllerClass
              * @psalm-var string|null $possibleAction

--- a/src/FileRouter.php
+++ b/src/FileRouter.php
@@ -130,19 +130,20 @@ final class FileRouter implements MiddlewareInterface
             $possibleAction,
         ];
 
-        if (!preg_match('#^(.*?)/([^/]+)/?$#', $directoryPath, $matches)) {
-            return;
+        if (preg_match('#^(.*?)/([^/]+)/?$#', $directoryPath, $matches)) {
+            $possibleAction = strtolower($controllerName);
+            $directoryPath = $matches[1];
+            $controllerName = $matches[2];
+        } else {
+            $directoryPath = $controllerName;
+            $controllerName = 'Index';
         }
-
-        $possibleAction = $controllerName;
-        $directoryPath = $matches[1];
-        $controllerName = $matches[2];
 
         yield [
             $this->cleanClassname(
                 $this->namespace . '\\' . $this->baseControllerDirectory . '\\' . $directoryPath . '\\' . $controllerName . $this->classPostfix
             ),
-            strtolower($possibleAction),
+            $possibleAction,
         ];
     }
 

--- a/src/FileRouter.php
+++ b/src/FileRouter.php
@@ -55,7 +55,8 @@ final class FileRouter implements MiddlewareInterface
             }
 
             /**
-             * @psalm-var class-string|null $controllerClass
+             * @psalm-var class-string $controllerClass
+             * @psalm-var string|null $possibleAction
              */
             [$controllerClass, $possibleAction] = $possibleEntrypoint;
             if (!class_exists($controllerClass)) {

--- a/src/FileRouter.php
+++ b/src/FileRouter.php
@@ -108,7 +108,7 @@ final class FileRouter implements MiddlewareInterface
 
         $controllerName = preg_replace_callback(
             '#(/.)#',
-            fn(array $matches) => strtoupper($matches[1]),
+            static fn(array $matches) => strtoupper($matches[1]),
             $path,
         );
 
@@ -143,7 +143,7 @@ final class FileRouter implements MiddlewareInterface
         ];
     }
 
-    protected function cleanClassname(string $className): string|array
+    private function cleanClassname(string $className): string
     {
         return str_replace(
             ['\\/\\', '\\/', '\\\\'],

--- a/tests/FileRouterTest.php
+++ b/tests/FileRouterTest.php
@@ -211,7 +211,27 @@ final class FileRouterTest extends TestCase
         $response = $router->process($request, $handler);
 
         $this->assertEquals(200, $response->getStatusCode());
-        $this->assertEquals('Hello, user action!', (string) $response->getBody());
+        $this->assertEquals('Hello, user/index action!', (string) $response->getBody());
+    }
+
+    public function testCustomRoute(): void
+    {
+        $router = $this->createRouter();
+        $router = $router
+            ->withNamespace('Yiisoft\FileRouter\Tests\Support\App2')
+            ->withBaseControllerDirectory('Action')
+            ->withClassPostfix('Action');
+
+        $handler = $this->createExceptionHandler();
+        $request = new ServerRequest(
+            method: 'GET',
+            uri: '/user/hello',
+        );
+
+        $response = $router->process($request, $handler);
+
+        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertEquals('Hello, user/hello action!', (string) $response->getBody());
     }
 
     public function testRoutesCollision(): void

--- a/tests/FileRouterTest.php
+++ b/tests/FileRouterTest.php
@@ -234,21 +234,37 @@ final class FileRouterTest extends TestCase
         $this->assertEquals('Hello, user/hello action!', (string) $response->getBody());
     }
 
-    public function testRoutesCollision(): void
+    #[DataProvider('dataRoutesCollision')]
+    public function testRoutesCollision(string $method, string $uri, string $expectedResponse): void
     {
         $router = $this->createRouter();
         $router = $router->withNamespace('Yiisoft\FileRouter\Tests\Support\App3');
 
         $handler = $this->createExceptionHandler();
         $request = new ServerRequest(
-            method: 'GET',
-            uri: '/user',
+            method: $method,
+            uri: $uri,
         );
 
         $response = $router->process($request, $handler);
 
         $this->assertEquals(200, $response->getStatusCode());
-        $this->assertEquals('Hello, Controller/UserController!', (string) $response->getBody());
+        $this->assertEquals($expectedResponse, (string) $response->getBody());
+    }
+
+    public static function dataRoutesCollision(): iterable
+    {
+        yield 'direct' => [
+            'GET',
+            '/user',
+            'Hello, Controller/UserController!',
+        ];
+
+        yield 'indirect' => [
+            'POST',
+            '/user',
+            'Hello, Controller/User/IndexController!',
+        ];
     }
 
     private function createRouter(): FileRouter

--- a/tests/Support/App2/Action/UserAction.php
+++ b/tests/Support/App2/Action/UserAction.php
@@ -18,6 +18,11 @@ class UserAction
 
     public function index(): ResponseInterface
     {
-        return new TextResponse('Hello, user action!');
+        return new TextResponse('Hello, user/index action!');
+    }
+
+    public function hello(): ResponseInterface
+    {
+        return new TextResponse('Hello, user/hello action!');
     }
 }

--- a/tests/Support/App3/Controller/User/IndexController.php
+++ b/tests/Support/App3/Controller/User/IndexController.php
@@ -13,4 +13,9 @@ class IndexController
     {
         return new TextResponse('Hello, Controller/User/IndexController!');
     }
+
+    public function create(): ResponseInterface
+    {
+        return new TextResponse('Hello, Controller/User/IndexController!');
+    }
 }

--- a/tests/Support/App3/Controller/User/IndexController.php
+++ b/tests/Support/App3/Controller/User/IndexController.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yiisoft\FileRouter\Tests\Support\App3\Controller\User;
+
+use HttpSoft\Response\TextResponse;
+use Psr\Http\Message\ResponseInterface;
+
+class IndexController
+{
+    public function index(): ResponseInterface
+    {
+        return new TextResponse('Hello, Controller/User/IndexController!');
+    }
+}

--- a/tests/Support/App3/Controller/UserController.php
+++ b/tests/Support/App3/Controller/UserController.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yiisoft\FileRouter\Tests\Support\App3\Controller;
+
+use HttpSoft\Response\TextResponse;
+use Psr\Http\Message\ResponseInterface;
+
+class UserController
+{
+    public function index(): ResponseInterface
+    {
+        return new TextResponse('Hello, Controller/UserController!');
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ✔️
| Breaks BC?    | ❌

Let's image a request to `/user/index`.
It has possible to controller+action variations:
1. `/Controller/UserController::index()`
2. `/Controller/User/IndexController::index()`

Order to find a possible method for `/user/index`:
- UserController::index()
- User/IndexController::index()

Custom routes make it able to write routes like the following: `user/index`, `user/main`, `user/default`, etc. In general just `^user/([^\/]+)$` (read regexp as "any chars if it doesn't contain a slash after user/")

So having `GET /user/hello/world` the `FileRouter` will look for:
- `/Controller/User/Hello/WorldController::index()`, `index` is a method converted from `GET` method
- `/Controller/User/HelloController::world()`, method doesn't matter

As a confirmation in tests look at https://github.com/yiisoft/file-router/blob/5e192a6cbfcd59e8dbb2f80bd9661d5a78f9725c/tests/FileRouterTest.php#L255